### PR TITLE
Fix GitHub repo link in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
     <!-- Footer -->
     <footer class="footer">
       <p>
-        <a href="https://github.com/tzuhuangyen/muripo-30days" target="_blank">GitHub Repo</a>
+        <a href="https://github.com/tznthou/muripo-hq" target="_blank">GitHub Repo</a>
         · MIT License
       </p>
     </footer>


### PR DESCRIPTION
## Summary
- update footer GitHub link to point to the muripo-hq repository

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b308ea538832b9625ed659db1dddb)